### PR TITLE
Added callback-wrapping feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,23 @@ The parameters of `ERR()` are:
 2. `callback` (optional) If the callback is set and an error is passed, it will call the callback with the modified stacktrace. Else it will throw the error
 
 The return value is true if there is an error. Else its false
+
+### Alternate Usage
+
+If all the work that is done in a function is done synchronously before an async call, it can be preferable to simply pass the callback directly to the async call, like this:
+
+```js
+function getUsers(db, callback) {
+  var sql = 'SELECT * FROM users';
+  db.query(sql, callback);
+}
+```
+
+`ERR()` can be used in this scenario as well. If it is passed a callback as its first argument, it will wrap the callback, caching the current stacktrace line. When the callback is executed, it will check for an error object and -- if one is exists -- it will add the cached stacktrace line to it:
+
+```js
+function getUsers(db, callback) {
+  var sql = 'SELECT * FROM users';
+  db.query(sql, ERR(callback));
+}
+```

--- a/tests.js
+++ b/tests.js
@@ -96,5 +96,40 @@ vows.describe('ERR function').addBatch({
       
       assert.equal(stackLinesBefore+1, stackLinesAfter);
     }
+  },
+  'when you call it with a callback as the only argument': {
+    'it returns a wrapped callback': function() {
+      var lineNumberRegex = /tests\.js:(\d+):\d+/;
+
+      var err = new Error();
+      var stackLinesBefore = err.stack.split("\n");
+      var syncLineNumber = lineNumberRegex.exec(stackLinesBefore[1])[1];
+
+      var stackLinesAfter;
+      var asyncLineNumber;
+      var wrappedCallback = ERR(function(_err) {
+        stackLinesAfter = _err.stack.split("\n");
+        asyncLineNumber = lineNumberRegex.exec(stackLinesAfter[1])[1];
+      });
+
+      wrappedCallback(err);
+      assert.equal(stackLinesBefore.length+3, stackLinesAfter.length);
+
+      // because `ERR(...)` is 6 lines after `new Error()` in this test
+      assert.equal(parseInt(asyncLineNumber), parseInt(syncLineNumber)+6);
+    }
+  },
+  'when you call it with a callback as the only argument then': {
+    'the wrapping does not interfere with `this` binding or passed args': function() {
+      var wrappedCallback = ERR(function(_err, arg1, arg2) {
+        assert.equal(this, "test_this");
+        assert.equal(err, null);
+        assert.equal(arg1, "arg1");
+        assert.equal(arg2, "arg2");
+      });
+
+      var err = null;
+      wrappedCallback.call("test_this", err, "arg1", "arg2");
+    }
   }
 }).run();    


### PR DESCRIPTION
@Pita: I'm not sure if you're interested in this feature, but it will be useful to us, so I thought I would open a pull request as an FYI.

Occasionally in our code base it is convenient to pass the callback function along directly, without wrapping it in another anonymous function -- for instance in situations like this:

``` js
function getUsers(db, callback) {
  var sql = 'SELECT * FROM users';
  db.query(sql, callback);
}
```

In order to use `ERR()`, we would have to add an anonymous function, like this:

``` js
function getUsers(db, callback) {
  var sql = 'SELECT * FROM users';
  db.query(sql, function(err, data) {
    if (ERR(err, callback)) return;
    callback(null, data);
  });
}
```

This pull request allows us to instead wrap the callback with `ERR()`, like this:

``` js
function getUsers(db, callback) {
  var sql = 'SELECT * FROM users';
  db.query(sql, ERR(callback));
}
```

The stacktrace line is cached at the moment of wrapping and re-used later if an error object is passed to the wrapped callback function.

I added a couple of tests and some documentation. Thanks for your work on this project!
