### PR TITLE
Made callback truly optional; made ERR() return the err

### DIFF
--- a/ERR.js
+++ b/ERR.js
@@ -46,18 +46,12 @@ module.exports = function (err, callback)
       err = new Error(err);
     }
   
-    //there is a callback, lets call it
+    //if a callback is passed, lets call it
     if(callback != null)
     {
       callback(err);
     }
-    //no callback, throw the error
-    else
-    {
-      throw err;
-    }
   }
   
-  //return true if an error happend
-  return err != null;
+  return err;
 }

--- a/README.md
+++ b/README.md
@@ -191,6 +191,6 @@ var ERR = require("async-stacktrace");
 The parameters of `ERR()` are: 
 
 1. `err` The error object (can be a string that describes the error too)
-2. `callback` (optional) If the callback is set and an error is passed, it will call the callback with the modified stacktrace. Else it will throw the error
+2. `callback` (optional) If the callback is set and an error is passed, it will call the callback with the modified stacktrace. Otherwise it will do nothing (the caller can pass the returned `err` object to the callback if desired).
 
-The return value is true if there is an error. Else its false
+The return value is the `err` object passed as the first parameter (if it was passed as a string, it will be returned as a first-class `Error()` object).

--- a/tests.js
+++ b/tests.js
@@ -20,13 +20,13 @@ vows.describe('ERR function').addBatch({
   }
 }).addBatch({
   'when you call it without an error' : {
-    'it returns false' : function() {
-      assert.isFalse(ERR());
+    'it returns falsy' : function() {
+      assert(!ERR());
     }
   },
   'when you call it with an error' : {
-    'it returns true' : function() {
-      assert.isTrue(ERR(new Error(), emptyFunc));
+    'it returns truthy' : function() {
+      assert(ERR(new Error(), emptyFunc));
     }
   },
   'when you give it a callback and an error': {
@@ -37,19 +37,11 @@ vows.describe('ERR function').addBatch({
     }
   },
   'when you give it no callback and an error': {
-    'it throws the error' : function() {
+    'it returns the error (so it can be passed to the callback)' : function() {
       var wasThrown = false;
       
-      try
-      {
-        ERR(new Error());
-      }
-      catch(e)
-      {
-        wasThrown = true;
-      }
-      
-      assert.isTrue(wasThrown);
+      var err = new Error();
+      assert.equal(ERR(err), err);
     }
   },
   'when you call it with a string as an error' : {


### PR DESCRIPTION
@Pita,

I understand if you're not interested in this pull request, as it is a breaking change for any code that relied on the throwing behavior of `ERR()`. However, it makes `ERR()` more flexible by allowing it to do just one thing: augment the stack of the passed error object.

For instance, instead of requiring that it be called like this:

``` javascript
if (ERR(err, callback)) return;
```

it can also be called like this:

``` javascript
if (err) return callback(ERR(err));
```

which is arguably clearer (the call to `callback` is explicit and the decoration of the `err` object is implicit).

On a more important note, it allows `callback` to be referenced just once in both error and non-error scenarios, like this:

``` javascript
function getUsers(db, callback) {
  var sql = 'SELECT * FROM users';
  db.query(sql, function(err, data) {
    console.log('Query complete.');
    callback(ERR(err), data);
  });
}
```

And it allows callback to be called in non-standard ways:

``` javascript
function getUsers(db, callback) {
  var sql = 'SELECT * FROM users';
  db.query(sql, function(err, data) {
    console.log('Query complete.');
    callback.apply(obj, ERR(err), global_data.concat([data]));
  });
}
```

Ok, that was a contrived example, but the point is that it brings more flexibility by allowing the calling code to take responsibility for calling the callback how and when it sees fit and allowing `ERR()` to do just one thing: augment the error object's stack.

This pull request also still supports the previous behavior: if a `callback` is passed as the second argument, it will still be called by `ERR()` as before. So the only code that will break is code that does not pass a callback and expects `ERR()` to throw an exception in the case of an error.

If exception-throwing behavior is desired, it can still be done -- and in an (arguably) clearer way -- by calling `ERR()` like this:

``` javascript
if (err) throw ERR(err);
```

I updated the relevant tests and documentation in this pull request.
